### PR TITLE
React createFactory compatibility

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,22 +1,3 @@
 {
-  "plugins": [
-    "transform-es2015-arrow-functions",
-    "transform-es2015-block-scoped-functions",
-    "transform-es2015-block-scoping",
-    "transform-es2015-classes",
-    "transform-es2015-computed-properties",
-    "transform-es2015-constants",
-    "transform-es2015-destructuring",
-    "transform-es2015-for-of",
-    "transform-es2015-function-name",
-    "transform-es2015-literals",
-    "transform-es2015-modules-commonjs",
-    "transform-es2015-object-super",
-    "transform-es2015-parameters",
-    "transform-es2015-shorthand-properties",
-    "transform-es2015-spread",
-    "transform-es2015-sticky-regex",
-    "transform-es2015-template-literals",
-    "transform-es2015-unicode-regex"
-  ]
+  "presets": ["babel-preset-es2015"]
 }

--- a/es6/remove-dom-shim.js
+++ b/es6/remove-dom-shim.js
@@ -1,0 +1,14 @@
+export default function ({types: t}) {
+  return {
+    visitor: {
+      CallExpression(path) {
+        const {object, property} = path.node.callee;
+        if (object && object.name === "React" &&
+            property && property.name === "createFactory")
+        {
+          path.replaceWith(path.node.arguments[0]);
+        }
+      }
+    }
+  };
+}

--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ export default function ({types: t}) {
   return {
     visitor: {
       CallExpression: {
-        enter: function (path) {
+        exit: function (path) {
           if (Object.keys(DOM).indexOf(path.node.callee.name) === -1) return;
 
           var props = getAttributes(path.node.arguments[0]);

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "babel-core": "^6.1.2",
     "babel-plugin-syntax-jsx": "^6.0.14",
-    "babel-preset-es2015": "^6.1.2",
+    "babel-preset-es2015": "^6.3.13",
     "esformatter": "^0.8.1",
     "esformatter-jsx": "^2.3.9",
     "react": "^0.14.2"

--- a/spec/remove-dom-shim.spec.js
+++ b/spec/remove-dom-shim.spec.js
@@ -1,0 +1,22 @@
+import { expect } from "chai";
+
+const transform = (str) => {
+  return require("babel-core").transform(str, {
+    plugins: ["../es6/remove-dom-shim"]
+  }).code
+}
+
+describe('Removes createFactory calls', () => {
+  it('converts a wrapped factory to a bare component', () => {
+    const code = 'React.createFactory(Component);';
+    expect(transform(code)).to.equal('Component;');
+  });
+
+  it('leaves other callExpressions intact', () => {
+    const code = 'React.doSomething(Component);';
+    expect(transform(code)).to.equal('React.doSomething(Component);');
+
+    const noObject = 'doSomething(Component);';
+    expect(transform(noObject)).to.equal('doSomething(Component);');
+  });
+});


### PR DESCRIPTION
The createFactory shim is no longer required when JSX is used. So it can be removed via the following transform.

Also addresses some Babel breaking changes.
