### PR TITLE
Added Plugin for Unhoisting Variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ require("babel-core").transform(code, {
     "js-to-jsx/es6/modules",
     "js-to-jsx/es6/arrow-functions",
     "js-to-jsx/es6/remove-dom-shim",
+    "js-to-jsx/es6/unhoist-variables",
     "syntax-jsx"
   ]
 }).code

--- a/bin/js-to-jsx.js
+++ b/bin/js-to-jsx.js
@@ -16,7 +16,7 @@ process.stdin.on("data", function(chunk) { buf += chunk; });
 process.stdin.on("end", function() {
   process.stdout.write(
     require("babel-core").transform(buf, {
-      plugins: [[root, { components: components }], root + "/es6/arrow-functions", root + "/es6/modules"],
+      plugins: [[root, { components: components }], root + "/es6/arrow-functions", root + "/es6/modules", root + "/es6/unhoist-variables"],
     }).code
   );
 });

--- a/es6/unhoist-variables.js
+++ b/es6/unhoist-variables.js
@@ -1,0 +1,35 @@
+export default function ({types: t}) {
+  return {
+    visitor: {
+      SequenceExpression(path) {
+        const assignments = path.node.expressions;
+
+        if (assignments.filter(t.isAssignmentExpression).length !== assignments.length) {
+          return;
+        }
+
+        let nextPath = path.parentPath;
+        assignments.forEach((node) => {
+          nextPath = nextPath.insertAfter(t.expressionStatement(node))[0];
+        });
+
+        path.remove();
+      },
+
+      ExpressionStatement(path) {
+        if (!t.isAssignmentExpression(path.node.expression)) { return; }
+
+        const left = path.node.expression.left;
+        const binding = path.scope.bindings[left.name];
+
+        if (binding && !binding.path.shouldSkip) {
+          path.replaceWith(
+            t.variableDeclaration("var", [t.VariableDeclarator(left, path.node.expression.right)])
+          );
+
+          binding.path.remove();
+        }
+      }
+    }
+  };
+}

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "devDependencies": {
     "chai": "^3.4.0",
+    "dedent": "^0.6.0",
     "eslint": "^1.9.0",
     "mocha": "^2.3.3"
   },

--- a/spec/es6.spec.js
+++ b/spec/es6.spec.js
@@ -1,4 +1,5 @@
 import { expect } from "chai";
+import dedent from "dedent";
 
 const transform = (str) => {
   return require("babel-core").transform(str, {
@@ -41,7 +42,13 @@ describe('Arrow functions', () => {
 
   it('with return', () => {
     const code = '(function(a, b) { return a + b; })';
-    expect(transform(code)).to.equal(`(a, b) => {\n  return a + b;\n};`);
+    expect(transform(code)).to.equal(
+      dedent`
+        (a, b) => {
+          return a + b;
+        };
+      `
+    );
   });
 
   it('bails out when `this` is used', () => {

--- a/spec/unhoist-variables-spec.js
+++ b/spec/unhoist-variables-spec.js
@@ -1,0 +1,78 @@
+import { expect } from "chai";
+import dedent from "dedent";
+
+const transform = (str) => {
+  return require("babel-core").transform(str, {
+    plugins: ["../es6/unhoist-variables"]
+  }).code
+}
+
+describe('Variable unhoisting', () => {
+  it('unhoists variables within the same scope', () => {
+    const code =
+      dedent`
+        var a;
+        var b;
+
+        a = 2;
+        b = 3;
+        c = 2;
+      `
+
+    const transformed =
+      dedent`
+        var a = 2;
+        var b = 3;
+
+        c = 2;
+      `
+
+    expect(transform(code)).to.equal(transformed);
+  });
+
+  it('handles sequence expressions', () => {
+    const code =
+      dedent`
+        var a, b, c, d;
+
+        a = 1, b = 2, c = 3, d = 4;
+      `
+
+    const transformed =
+      dedent`
+        var a = 1;
+        var b = 2;
+        var c = 3;
+        var d = 4;
+      `
+
+    expect(transform(code)).to.equal(transformed);
+  });
+
+  it('does not unhoist variables when assignment is in different scope', () => {
+    const code =
+      dedent`
+        var a;
+
+        function b() {
+          a = 3;
+        }
+
+        function c() {
+          a = 4;
+        }
+      `
+    expect(transform(code)).to.equal(code);
+  });
+
+  it('leaves mixed sequence expressions untouched', () => {
+    const code =
+      dedent`
+        var a, b, c, d;
+
+        a = 1, b = 2, 2 * 2, 3 * 3;
+      `
+
+    expect(transform(code)).to.equal(code);
+  });
+});


### PR DESCRIPTION
Fixes #10. Adds a plugin to the `es6/` folder that can be used to reverse the explicit variable hoisting that some transpiled languages like LiveScript end up doing. Used to turn:

``` js
var a, b, c;
a = 1;
b = 2;
c = 3;
```

Into:

``` js
var a = 1;
var b = 2;
var c = 3;
```
