### PR TITLE
Replace StringLiterals with JSXText

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,8 +17,10 @@ export default function ({types: t}) {
 
   const processChildren = (children) => {
     return children.map(c => {
-      if (t.isJSXElement(c) || t.isStringLiteral(c) || t.isJSXExpressionContainer(c)) {
+      if (t.isJSXElement(c) || t.isJSXExpressionContainer(c)) {
         return c;
+      } else if (t.isStringLiteral(c)) {
+        return t.JSXText(c.value);
       } else {
         return t.JSXExpressionContainer(c);
       }

--- a/spec/index.spec.js
+++ b/spec/index.spec.js
@@ -13,7 +13,7 @@ describe('JSX Elements', () => {
 
   it('With text child', () => {
     const code = 'div(null, "Hello")';
-    expect(transform(code)).to.equal('<div>"Hello"</div>;');
+    expect(transform(code)).to.equal('<div>Hello</div>;');
   });
 
   it('With element child', () => {


### PR DESCRIPTION
Fixes #9 (as it happens). The [change mentioned](https://github.com/babel/babel/pull/3195) in #9 prevents us from using StringLiterals in calls like `p(null, "Hello")`, it has to be JSXText instead
